### PR TITLE
[Bugfix] tonumber(ffi.C.wcslen())

### DIFF
--- a/src/Yutils.lua
+++ b/src/Yutils.lua
@@ -3171,7 +3171,7 @@ Yutils = {
 						end
 						-- Get utf16 text
 						text = utf8_to_utf16(text)
-						local text_len = ffi.C.wcslen(text)
+						local text_len = tonumber(ffi.C.wcslen(text))
 						-- Get text extents with this font
 						local size = ffi.new("SIZE[1]")
 						ffi.C.GetTextExtentPoint32W(dc, text, text_len, size)
@@ -3190,7 +3190,7 @@ Yutils = {
 						local shape, shape_n = {}, 0
 						-- Get utf16 text
 						text = utf8_to_utf16(text)
-						local text_len = ffi.C.wcslen(text)
+						local text_len = tonumber(ffi.C.wcslen(text))
 						-- Add path to device context
 						if text_len > 8192 then
 							error("text too long", 2)


### PR DESCRIPTION
<img align="right" width="400" src="https://user-images.githubusercontent.com/112813970/205067842-bb622e5b-bb13-4438-b47a-05b88805b8ac.png" />  
<img align="right" width="400" src="https://user-images.githubusercontent.com/112813970/205069278-ce0c6243-cd6c-4698-b679-61115f5aab2e.png" />    

We found that the current Yutils.lua will run into problems if character spacing is not set to 0. This is reproduced in sepro's and my test.  

We had a look at several different versions of Yutils.lua, and we believe this `tonumber()` is the fix to the problem.  

sepro told me to make this pull request. we will also inform arch1t3cht about this issue.  

### Steps to reproduce
1. Install zf.everythingShape from [https://github.com/TypesettingTools/zeref-Aegisub-Scripts](https://github.com/TypesettingTools/zeref-Aegisub-Scripts)  
2. Open style manager and set style character spacing to any value other than 0.0. For example, 1.0.  
3. Create a line of subtitle and use the „Shape To Clip“ function inside zf.everythingShape on the subtitle.  

Thank you.  